### PR TITLE
Enhance GitHub App Token Generator with permission downgrade capabilities

### DIFF
--- a/create-github-app-token/src/tasks/run.ts
+++ b/create-github-app-token/src/tasks/run.ts
@@ -73,7 +73,7 @@ async function run() {
           } catch (err: any) {
             throw new Error(`Failed to parse service connection permissions JSON: ${err.message}`);
           }
-          tl.warning(`Forcing permisssions from service connection`);
+          tl.warning(`Forcing permissions from service connection`);
           console.log(`Forced permissions: ${JSON.stringify(permissions)}`);
         }
 

--- a/create-github-app-token/src/tasks/run.ts
+++ b/create-github-app-token/src/tasks/run.ts
@@ -18,6 +18,19 @@ async function run() {
     let repositoriesList = tl.getInput('repositories', false)?.trim() || undefined;
     const connectedServiceName = tl.getInput('githubAppConnection', false);
     const skipTokenRevoke = tl.getBoolInput('skipTokenRevoke', false);
+    const permissionsInput = tl.getInput('permissions', false);
+
+    let permissions: { [key: string]: string } | undefined = undefined;
+    if (permissionsInput) {
+      try {
+        permissions = JSON.parse(permissionsInput);
+        if (typeof permissions !== 'object' || permissions === null) {
+          throw new Error('Permissions must be an object');
+        }
+      } catch (err: any) {
+        throw new Error(`Failed to parse permissions JSON: ${err.message}`);
+      }
+    }
 
     let privateKey = '';
 
@@ -29,7 +42,11 @@ async function run() {
     console.log(`Owner: ${owner}`);
     console.log(`Account Type: ${accountType}`);
     console.log(`Repositories List: ${repositoriesList ? repositoriesList : 'Not Provided'}`);
+    console.log(`Permissions: ${permissions ? JSON.stringify(permissions) : 'Not Provided'}`);
     console.log(`Skip Token Revoke: ${skipTokenRevoke}`);
+    if (permissions) {
+      console.log(`Permissions: ${JSON.stringify(permissions)}`);
+    }
     console.log('##[endgroup]')
 
     // Order of precedence for private key:
@@ -43,6 +60,23 @@ async function run() {
         privateKey = endpoint.parameters['certificate'];
         appClientId = endpoint.parameters['appClientId'];
         baseUrl = endpoint.parameters['url'] || baseUrl;
+        
+        const limitPermissions = endpoint.parameters['limitPermissions'];
+        if (limitPermissions) {
+          console.log('Limiting permissions to those defined in the service connection');
+          try {
+            permissions = JSON.parse(limitPermissions);
+            if (typeof permissions !== 'object' || permissions === null) {
+              throw new Error('Service connection permissions must be an object');
+            }
+            console.log('Using permissions from service connection, overriding task input if any');
+          } catch (err: any) {
+            throw new Error(`Failed to parse service connection permissions JSON: ${err.message}`);
+          }
+          tl.warning(`Forcing permisssions from service connection`);
+          console.log(`Forced permissions: ${JSON.stringify(permissions)}`);
+        }
+
         const forceRepoScope = endpoint.parameters['forceRepoScope']?.toLowerCase() === 'true';
         if (forceRepoScope) {
           console.log('Forcing repo scope)');
@@ -125,7 +159,7 @@ async function run() {
     const installationId = await githubService.getInstallationId(jwtToken, owner, isOrg , repositories);
     console.log(`Found installation ID: ${installationId}`);
 
-    const token = await githubService.getInstallationToken(jwtToken, installationId, repositories);
+    const token = await githubService.getInstallationToken(jwtToken, installationId, repositories, permissions);
     console.log('Installation token generated successfully');
 
     // Set the output variables

--- a/create-github-app-token/task.json
+++ b/create-github-app-token/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 0
+        "Patch": 1
     },
     "instanceNameFormat": "Create GitHub App Installation Token",
     "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "create-github-app-token",
     "name": "GitHub App Token Generator",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "publisher": "INSERT YOUR PUBLISHER HERE",
     "public": false,
     "targets": [
@@ -52,6 +52,7 @@
                 "name": "githubappauthentication",
                 "isVerifiable": false,
                 "displayName": "GitHub App",
+                "helpMarkDown": "GitHub App Service Connection. See [azure-pipelines-create-github-app-token-task](https://github.com/tspascoal/azure-pipelines-create-github-app-token-task) for more information.",
                 "url": {
                     "value": "https://api.github.com/",
                     "displayName": "GitHub API URL",
@@ -81,6 +82,17 @@
                                 "isConfidential": true,
                                 "validation": {
                                     "isRequired": true,
+                                    "dataType": "string"
+                                }
+                            },
+                            {
+                                "id": "limitPermissions",
+                                "name": "Limit Token Permissions",
+                                "description": "Optional JSON object to restrict token permissions. If empty will use app permissions or permissions set at task level. If provided, this will override any permissions set in the task input Format: {\"permission\":\"accesstype\"} EG: {\"contents\":\"read\",\"issues\":\"write\"}. see permissions parameter https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app for full list of permissions.",
+                                "inputMode": "textarea",
+                                "isConfidential": false,
+                                "validation": {
+                                    "isRequired": false,
                                     "dataType": "string"
                                 }
                             },


### PR DESCRIPTION
The installation token can (optionally) have less permissions than the GitHub App itself, useful for downgrading permissions for specific cases.

The permissions can be downgraded by specifying a parameter in the task or at a service connection level. In that case the downgrade is enforced

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73-R74): Added details on how to restrict token permissions using the `permissions` parameter and provided examples for different use cases. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73-R74) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R94-R96) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-R125) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R134-R137) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R146-R152) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R171-R193) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R210-R213)

Enhancements to GitHub service class:

* [`create-github-app-token/src/core/github-service.ts`](diffhunk://#diff-aa6ef319c0002a3cde44c71ee24257a4ee65cfca1f8f60d9e1da0e6c548bc17dR62-R64): Added support for specifying permissions when creating installation tokens and updated the `getInstallationToken` method to handle the new `permissions` parameter. [[1]](diffhunk://#diff-aa6ef319c0002a3cde44c71ee24257a4ee65cfca1f8f60d9e1da0e6c548bc17dR62-R64) [[2]](diffhunk://#diff-aa6ef319c0002a3cde44c71ee24257a4ee65cfca1f8f60d9e1da0e6c548bc17dR92-R93) [[3]](diffhunk://#diff-aa6ef319c0002a3cde44c71ee24257a4ee65cfca1f8f60d9e1da0e6c548bc17dR109-R113) [[4]](diffhunk://#diff-aa6ef319c0002a3cde44c71ee24257a4ee65cfca1f8f60d9e1da0e6c548bc17dR123-R133) [[5]](diffhunk://#diff-aa6ef319c0002a3cde44c71ee24257a4ee65cfca1f8f60d9e1da0e6c548bc17dR142-R175)

Task input handling:

* [`create-github-app-token/src/tasks/run.ts`](diffhunk://#diff-6a28a930749e40064e80723186ba8f9ff739fddb7433801c32aeedb5ff185031R21-R33): Added logic to parse and handle the `permissions` input, including validation and precedence over service connection permissions. [[1]](diffhunk://#diff-6a28a930749e40064e80723186ba8f9ff739fddb7433801c32aeedb5ff185031R21-R33) [[2]](diffhunk://#diff-6a28a930749e40064e80723186ba8f9ff739fddb7433801c32aeedb5ff185031R45-R49) [[3]](diffhunk://#diff-6a28a930749e40064e80723186ba8f9ff739fddb7433801c32aeedb5ff185031R63-R79) [[4]](diffhunk://#diff-6a28a930749e40064e80723186ba8f9ff739fddb7433801c32aeedb5ff185031L128-R162)

Version updates:

* [`create-github-app-token/task.json`](diffhunk://#diff-e763f5a7cda9b47974cfd4a1936b5eb218af9da849b961ef30516274376409d6L13-R13): Updated the task version to `1.0.1`.
* [`vss-extension.json`](diffhunk://#diff-81f89915829f6a1a40da4191994bd65d445564779e6bea3e87dafc0ad7abb6e2L5-R5): Updated the extension version to `1.0.1` and added a description for the new `limitPermissions` field in the service connection configuration. [[1]](diffhunk://#diff-81f89915829f6a1a40da4191994bd65d445564779e6bea3e87dafc0ad7abb6e2L5-R5) [[2]](diffhunk://#diff-81f89915829f6a1a40da4191994bd65d445564779e6bea3e87dafc0ad7abb6e2R55) [[3]](diffhunk://#diff-81f89915829f6a1a40da4191994bd65d445564779e6bea3e87dafc0ad7abb6e2R88-R98)