### PR TITLE
Owner input is now optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # GitHub App Token Generator for Azure Pipelines
 
-
 Azure Pipelines extension to create a GitHub App installation tokens that can be used for calling GitHub APIs. It's particularly useful when you need to interact with GitHub repositories using a GitHub App instead of personal access tokens or other authentication methods. The extension include a task that generates GitHub App installation tokens for API authentication and a service connection definition that allows you to save the GitHub App data and credentials securely in Azure DevOps.
 
 > [!NOTE]
@@ -65,7 +64,7 @@ steps:
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | githubAppConnection | No | The GitHub App connection to use (preferred method) |
-| owner | Yes | The GitHub organization name or user account where the app is installed |
+| owner | No | The GitHub organization name or user account where the app is installed. If not provided it will automatically fetched from `Build.Repository.Name` variable. |
 | repositories | No | Comma-separated list of repositories to scope the token to. If empty, token will be scoped to all repositories (in which the app has access to) |
 | appClientId | No* | The GitHub App ID (required if not using service connection) |
 | certificate | No* | The PEM certificate content (required if not using service connection) |
@@ -111,7 +110,6 @@ steps:
   name: token
   inputs:
     githubAppConnection: 'MyGitHubAppConnection'
-    owner: 'MyOrg'
 - bash: |
     gh api \
     --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -160,8 +158,6 @@ steps:
   name: githubAuth
   inputs:
     githubAppConnection: 'MyGitHubAppConnection'
-    owner: 'MyOrg'
-    
 
 - script: |
     curl -H "Authorization: Bearer $(githubAuth.installationToken)" https://api.github.com/repos/MyOrg/MyRepo/issues | jq

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ steps:
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | githubAppConnection | No | The GitHub App connection to use (preferred method) |
-| owner | No | The GitHub organization name or user account where the app is installed. If not provided it will automatically fetched from `Build.Repository.Name` variable. |
+| owner | No | The GitHub organization name or user account where the app is installed. If not provided, it will be automatically fetched from the `Build.Repository.Name` variable. |
 | repositories | No | Comma-separated list of repositories to scope the token to. If empty, token will be scoped to all repositories (in which the app has access to) |
 | appClientId | No* | The GitHub App ID (required if not using service connection) |
 | certificate | No* | The PEM certificate content (required if not using service connection) |

--- a/create-github-app-token/src/core/github-service.ts
+++ b/create-github-app-token/src/core/github-service.ts
@@ -1,7 +1,7 @@
 import * as tl from 'azure-pipelines-task-lib/task';
 import axios, { AxiosInstance } from 'axios';
 import * as jwt from 'jsonwebtoken';
-import { ProxyConfig, ProxyOptions } from './proxy-config';
+import { ProxyConfig } from './proxy-config';
 import { validateRepositoryName } from '../utils/validation';
 import * as constants from '../utils/constants';
 
@@ -106,6 +106,13 @@ export class GitHubService {
             tl.debug(`App slug: ${response.data.app_slug}`);
             tl.debug(`Target type: ${response.data.target_type}`);
 
+        } catch (err: any) {
+            if(err.status && err.status === 404) {
+                tl.error(`Couldn't get installation id. Validate owner${repositories.length > 0 ? ' and repository' : ''} and if  GitHub App is installed on ${owner}${repositories.length > 0 ? ' and with access to repository' : ''}.`);
+            } else {
+                tl.error(`Error getting installation ID. Please validate the owner and repository (and account type): ${err.message}`);
+            }
+            throw err;
         } finally {
             console.log('##[endgroup]')
         }

--- a/create-github-app-token/src/tasks/run.ts
+++ b/create-github-app-token/src/tasks/run.ts
@@ -3,14 +3,26 @@ import * as fs from 'fs';
 import { GitHubService } from '../core/github-service';
 import { ProxyConfig } from '../core/proxy-config';
 import * as constants from '../utils/constants';
-import { getRepoName } from '../utils/github'; 
+import { getRepoName, getOwnerName } from '../utils/github';
 import { validateAccountType } from '../utils/validation';
 
 async function run() {
   try {
     let baseUrl = constants.DEFAULT_API_URL;
 
-    const owner = tl.getInputRequired('owner')!;
+    const provider = tl.getVariable('Build.Repository.Provider');
+    let owner = tl.getInput('owner', false)
+    const nwo = tl.getVariable('Build.Repository.Name')!;
+
+    // If owner is not provided,get it from the repository name (provider has to be GitHub)
+    if (!owner) {
+      failIfProviderIsNotGitHub(provider, "If owner is not provided, the repository provider must be GitHub");
+      const extractedOwner = getOwnerName(nwo);
+      console.log(`Extracted owner from Build.Repository.Name: ${extractedOwner}`);
+
+      owner = extractedOwner;
+    }
+
     const accountType = tl.getInput('accountType', false) || constants.ACCOUNT_TYPE_ORG;
     let appClientId = tl.getInput('appClientId', false) || undefined;
     const privateKeyPath = tl.getInput('certificateFile', false) || '';
@@ -60,7 +72,7 @@ async function run() {
         privateKey = endpoint.parameters['certificate'];
         appClientId = endpoint.parameters['appClientId'];
         baseUrl = endpoint.parameters['url'] || baseUrl;
-        
+
         const limitPermissions = endpoint.parameters['limitPermissions'];
         if (limitPermissions) {
           console.log('Limiting permissions to those defined in the service connection');
@@ -80,26 +92,24 @@ async function run() {
         const forceRepoScope = endpoint.parameters['forceRepoScope']?.toLowerCase() === 'true';
         if (forceRepoScope) {
           console.log('Forcing repo scope)');
-          const provider = tl.getVariable('Build.Repository.Provider');
           console.log(`Repo Provider: ${provider}`);
 
-            if (provider?.toLowerCase() === 'github') {
-            const repo = tl.getVariable('Build.Repository.Name');
-            if (repo) {
-              const forcedRepo = getRepoName(repo);
-              console.log(`Forcing repo scope to ${forcedRepo}`);
-              if (!repositoriesList) {
-                tl.warning(`Forcing repo scope to ${forcedRepo}, even though no repositories were provided`);
-              } else if(repositoriesList != forcedRepo) {
-                tl.warning(`Forcing repo scope to ${forcedRepo}. Ignoring repositories input ${repositoriesList}`);
-              }
-              
-              repositoriesList = forcedRepo;
-            }
-          } else {
-            tl.setResult(tl.TaskResult.Failed, 'Forcing repo scope is only supported for GitHub repositories. Repo provider is ${provider}');
-            return;
+          failIfProviderIsNotGitHub(provider, "Forcing repo scope is only supported for GitHub repositories. Repo provider is ${provider}");
+          const forcedRepo = getRepoName(nwo);
+          console.log(`Forcing repo scope to ${forcedRepo}`);
+          if (!repositoriesList) {
+            tl.warning(`Forcing repo scope to ${forcedRepo}, even though no repositories were provided`);
+          } else if (repositoriesList != forcedRepo) {
+            tl.warning(`Forcing repo scope to ${forcedRepo}. Ignoring repositories input ${repositoriesList}`);
           }
+
+          const forcedOwner = getOwnerName(nwo);
+            if (owner?.toLowerCase() !== forcedOwner?.toLowerCase()) {
+            tl.warning(`Forcing owner ${forcedOwner} previously ${owner}. This may fail if there is an owner type mismatch`);
+            owner = getOwnerName(nwo);
+          }
+          
+          repositoriesList = forcedRepo;
         }
 
         console.log(`Base URL: ${baseUrl}`);
@@ -111,7 +121,7 @@ async function run() {
         // Unreachable code since it forces a required check, but just in case
         console.log('##[endgroup]');
         tl.setResult(tl.TaskResult.Failed, `Service connection ${connectedServiceName} not found`);
-        
+
         return;
       }
     }
@@ -135,7 +145,7 @@ async function run() {
     }
 
     // If repositories is define we don't really need account type
-    if(!repositoriesList)  {
+    if (!repositoriesList) {
       validateAccountType(accountType);
     }
 
@@ -156,7 +166,7 @@ async function run() {
     }
 
     const isOrg = accountType.toLowerCase() === constants.ACCOUNT_TYPE_ORG;
-    const installationId = await githubService.getInstallationId(jwtToken, owner, isOrg , repositories);
+    const installationId = await githubService.getInstallationId(jwtToken, owner, isOrg, repositories);
     console.log(`Found installation ID: ${installationId}`);
 
     const token = await githubService.getInstallationToken(jwtToken, installationId, repositories, permissions);
@@ -177,3 +187,10 @@ async function run() {
 }
 
 run();
+
+function failIfProviderIsNotGitHub(provider: string | undefined, message: string = 'Provider is not GitHub') {
+  if (provider?.toLowerCase() !== 'github') {
+    tl.error(message)
+    throw new Error(message);
+  }
+}

--- a/create-github-app-token/src/tasks/run.ts
+++ b/create-github-app-token/src/tasks/run.ts
@@ -94,7 +94,7 @@ async function run() {
           console.log('Forcing repo scope)');
           console.log(`Repo Provider: ${provider}`);
 
-          failIfProviderIsNotGitHub(provider, "Forcing repo scope is only supported for GitHub repositories. Repo provider is ${provider}");
+          failIfProviderIsNotGitHub(provider, `Forcing repo scope is only supported for GitHub repositories. Repo provider is ${provider}`);
           const forcedRepo = getRepoName(nwo);
           console.log(`Forcing repo scope to ${forcedRepo}`);
           if (!repositoriesList) {

--- a/create-github-app-token/src/utils/github.ts
+++ b/create-github-app-token/src/utils/github.ts
@@ -7,3 +7,13 @@
 export function getRepoName(nwo: string) {
   return nwo.split("/")[1];
 }
+
+/**
+ * Extracts the owner name from a GitHub repository's "name with owner" (NWO) string.
+ *
+ * @param nwo - The "name with owner" string in the format "owner/repo".
+ * @returns The owner name (the part before the slash).
+ */
+export function getOwnerName(nwo: string) {
+  return nwo.split("/")[0];
+}

--- a/create-github-app-token/task.json
+++ b/create-github-app-token/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "instanceNameFormat": "Create GitHub App Installation Token",
     "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "create-github-app-token",
     "name": "GitHub App Token Generator",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "publisher": "INSERT YOUR PUBLISHER HERE",
     "public": false,
     "targets": [
@@ -98,7 +98,7 @@
                             },
                             {
                                 "id": "forceRepoScope",
-                                "name": "Scope to current repository",
+                                "name": "Force Scope to current repository",
                                 "description": "If true, the token will be scoped to the current repository (only works for GitHub repositories. Will faild if set to true and repository is not a GitHub repository)",
                                 "inputMode": "checkbox",
                                 "isConfidential": false,


### PR DESCRIPTION
Owner input is now optional, no need to pass unless the owner is different from the repository owner you are using.

- If owner is not provided, it will be inferred from the `Build.Repository.Name` variable 
- If the repository scope is forced via a service connection then owner is also forced

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R67): Updated the `owner` parameter to be optional, with automatic fetching from `Build.Repository.Name` if not provided.

### Error Handling Improvements:
* [`create-github-app-token/src/core/github-service.ts`](diffhunk://#diff-aa6ef319c0002a3cde44c71ee24257a4ee65cfca1f8f60d9e1da0e6c548bc17dR109-R115): Enhanced error handling to provide more specific error messages when fetching the installation ID fails.

### New Utility Functions:
* [`create-github-app-token/src/utils/github.ts`](diffhunk://#diff-607c23e08ba94bb1ddcd07c1b752cedf6d3352ad94cbe380486f3633d7bbed4eR10-R19): Added a new function `getOwnerName` to extract the owner name from the repository name.

### Task Configuration Updates:
* [`create-github-app-token/src/tasks/run.ts`](diffhunk://#diff-6a28a930749e40064e80723186ba8f9ff739fddb7433801c32aeedb5ff185031L6-R25): Modified the task to fetch the owner from `Build.Repository.Name` if not provided and added a function to ensure the repository provider is GitHub. [[1]](diffhunk://#diff-6a28a930749e40064e80723186ba8f9ff739fddb7433801c32aeedb5ff185031L6-R25) [[2]](diffhunk://#diff-6a28a930749e40064e80723186ba8f9ff739fddb7433801c32aeedb5ff185031L83-R112) [[3]](diffhunk://#diff-6a28a930749e40064e80723186ba8f9ff739fddb7433801c32aeedb5ff185031R190-R196)

### Extension Manifest Updates:
* [`vss-extension.json`](diffhunk://#diff-81f89915829f6a1a40da4191994bd65d445564779e6bea3e87dafc0ad7abb6e2L5-R5): Updated the version to `1.0.2` and renamed the `forceRepoScope` input for clarity. [[1]](diffhunk://#diff-81f89915829f6a1a40da4191994bd65d445564779e6bea3e87dafc0ad7abb6e2L5-R5) [[2]](diffhunk://#diff-81f89915829f6a1a40da4191994bd65d445564779e6bea3e87dafc0ad7abb6e2L101-R101)