### PR TITLE
Add tokenExpiration as an output variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ steps:
 
 | Variable | Description |
 |----------|-------------|
-| $(installationToken) | The generated GitHub App installation token |
-| $(installationId) | The ID of the GitHub App installation |
+| installationToken | The generated GitHub App installation token |
+| installationId | The ID of the GitHub App installation |
+| tokenExpiration | The expiration date and time of the generated token (ISO 8601 format) |
 
 ### Service Connection Setup (optional)
 

--- a/create-github-app-token/src/core/github-service.ts
+++ b/create-github-app-token/src/core/github-service.ts
@@ -135,9 +135,10 @@ export class GitHubService {
      * It logs details about the token creation process, including repository selection and permissions.
      * The token is scoped based on the provided repositories or the entire installation if no repositories are specified.
      */
-    async getInstallationToken(jwtToken: string, installationId: number, repositories: string[] = [], permissions?: { [key: string]: string }): Promise<string> {
+    async getInstallationToken(jwtToken: string, installationId: number, repositories: string[] = [], permissions?: { [key: string]: string }): Promise<{ token: string; expiresAt: string }> {
         let groupName = '';
         let token = '';
+        let expiresAt = '';
         if (repositories.length > 0) {
             groupName = `##[group]Create installation token for repositories: ${repositories} with ${installationId}`;
         } else {
@@ -167,10 +168,11 @@ export class GitHubService {
             );
             
             token = response.data.token;
+            expiresAt = response.data.expires_at;
 
             this.dumpHeaders(response.headers);
 
-            tl.debug(`Expires: ${response.data.expires_at}`);
+            tl.debug(`Expires: ${expiresAt}`);
             console.log(`Repository selection: ${response.data.repository_selection}`);
             const permissionsCsv = this.formatPermissions(response.data.permissions);
             console.log(`Permissions: ${permissionsCsv}`);
@@ -179,7 +181,7 @@ export class GitHubService {
             console.log('##[endgroup]')
         }
 
-        return token;
+        return { token, expiresAt };
     }
 
     async revokeInstallationToken(token: string): Promise<boolean> {

--- a/create-github-app-token/src/tasks/run.ts
+++ b/create-github-app-token/src/tasks/run.ts
@@ -169,12 +169,13 @@ async function run() {
     const installationId = await githubService.getInstallationId(jwtToken, owner, isOrg, repositories);
     console.log(`Found installation ID: ${installationId}`);
 
-    const token = await githubService.getInstallationToken(jwtToken, installationId, repositories, permissions);
+    const { token, expiresAt } = await githubService.getInstallationToken(jwtToken, installationId, repositories, permissions);
     console.log('Installation token generated successfully');
 
     // Set the output variables
     tl.setVariable(constants.INSTALLATIONID_OUTPUT_VARNAME, installationId.toString(), false);
     tl.setVariable(constants.INSTALLATION_TOKEN_OUTPUT_VARNAME, token, true); // secret
+    tl.setVariable(constants.TOKEN_EXPIRATION_OUTPUT_VARNAME, expiresAt, false);
 
     // Save state for post job
     tl.setTaskVariable(constants.INSTALLATION_TOKEN_OUTPUT_VARNAME, token, true); // secret

--- a/create-github-app-token/src/utils/constants.ts
+++ b/create-github-app-token/src/utils/constants.ts
@@ -3,6 +3,7 @@ export const JWT_EXPIRATION = 10 * 60; // 10 minutes in seconds (max is 10 minut
 
 export const INSTALLATIONID_OUTPUT_VARNAME = 'installationId';
 export const INSTALLATION_TOKEN_OUTPUT_VARNAME = 'installationToken';
+export const TOKEN_EXPIRATION_OUTPUT_VARNAME = 'tokenExpiration';
 export const SKIP_TOKEN_TASK_VARNAME = 'skipTokenRevoke';
 export const BASE_URL_TASK_VARNAME = 'baseUrl';
 

--- a/create-github-app-token/task.json
+++ b/create-github-app-token/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 2
+        "Patch": 3
     },
     "instanceNameFormat": "Create GitHub App Installation Token",
     "inputs": [
@@ -91,6 +91,10 @@
         {
             "name": "installationId",
             "description": "The ID of the GitHub App installation"
+        },
+        {
+            "name": "tokenExpiration",
+            "description": "The expiration date and time of the generated token (ISO 8601 format)"
         }
     ],
     "execution": {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "create-github-app-token",
     "name": "GitHub App Token Generator",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "publisher": "INSERT YOUR PUBLISHER HERE",
     "public": false,
     "targets": [


### PR DESCRIPTION
Add token expiration data as an output variable so pipeline authors can check if a token has expired

Enhancements to token generation:

* [`create-github-app-token/src/core/github-service.ts`](diffhunk://#diff-aa6ef319c0002a3cde44c71ee24257a4ee65cfca1f8f60d9e1da0e6c548bc17dL138-R141): Modified the `getInstallationToken` method to return an object containing both the token and its expiration date (`expiresAt`). Updated the method to log the expiration date and return the new object format. [[1]](diffhunk://#diff-aa6ef319c0002a3cde44c71ee24257a4ee65cfca1f8f60d9e1da0e6c548bc17dL138-R141) [[2]](diffhunk://#diff-aa6ef319c0002a3cde44c71ee24257a4ee65cfca1f8f60d9e1da0e6c548bc17dR171-R175) [[3]](diffhunk://#diff-aa6ef319c0002a3cde44c71ee24257a4ee65cfca1f8f60d9e1da0e6c548bc17dL182-R184)
* [`create-github-app-token/src/tasks/run.ts`](diffhunk://#diff-6a28a930749e40064e80723186ba8f9ff739fddb7433801c32aeedb5ff185031L172-R178): Updated the `run` function to handle the new object format returned by `getInstallationToken` and set the `tokenExpiration` output variable.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R83): Added a description for the `tokenExpiration` variable in the table of variables.

Configuration updates:

* [`create-github-app-token/task.json`](diffhunk://#diff-e763f5a7cda9b47974cfd4a1936b5eb218af9da849b961ef30516274376409d6L13-R13): Incremented the patch version and added the `tokenExpiration` input description. [[1]](diffhunk://#diff-e763f5a7cda9b47974cfd4a1936b5eb218af9da849b961ef30516274376409d6L13-R13) [[2]](diffhunk://#diff-e763f5a7cda9b47974cfd4a1936b5eb218af9da849b961ef30516274376409d6R94-R97)
* [`vss-extension.json`](diffhunk://#diff-81f89915829f6a1a40da4191994bd65d445564779e6bea3e87dafc0ad7abb6e2L5-R5): Updated the version to `1.0.3`.
* [`create-github-app-token/src/utils/constants.ts`](diffhunk://#diff-1b525116fd14c64154e278bcb110f7ffefcd31d70763065c83f7951b42f57375R6): Added `TOKEN_EXPIRATION_OUTPUT_VARNAME` constant.