### PR TITLE
Fix base URL retrieval from service connection

### DIFF
--- a/create-github-app-token/src/tasks/run.ts
+++ b/create-github-app-token/src/tasks/run.ts
@@ -76,7 +76,7 @@ async function run() {
       if (endpoint) {
         privateKey = endpoint.parameters['certificate'];
         appClientId = endpoint.parameters['appClientId'];
-        baseUrl = endpoint.parameters['url'] || baseUrl;
+        baseUrl = tl.getEndpointUrl(connectedServiceName, true) || baseUrl;
 
         const limitPermissions = endpoint.parameters['limitPermissions'];
         if (limitPermissions) {

--- a/create-github-app-token/test/setup.ts
+++ b/create-github-app-token/test/setup.ts
@@ -18,6 +18,7 @@ jest.mock('azure-pipelines-task-lib/task', () => ({
   setVariable: jest.fn(),
   setTaskVariable: jest.fn(),
   getTaskVariable: jest.fn(),
+  getEndpointUrl: jest.fn(),
   getEndpointAuthorization: jest.fn(),
   getHttpProxyConfiguration: jest.fn(),
   debug: jest.fn(),

--- a/create-github-app-token/test/tasks/run.test.ts
+++ b/create-github-app-token/test/tasks/run.test.ts
@@ -92,11 +92,11 @@ describe('run task logic', () => {
         }
       });
 
+      mockedTl.getEndpointUrl.mockReturnValue('https://api.github.com/');
       mockedTl.getEndpointAuthorization.mockReturnValue({
         parameters: {
           'certificate': 'mock-pem-key',
           'appClientId': 'test-app-id',
-          'url': 'https://api.github.com/'
         }
       } as any);
 
@@ -845,11 +845,11 @@ describe('run task logic', () => {
         }
       });
 
+      mockedTl.getEndpointUrl.mockReturnValue(customBaseUrl);
       mockedTl.getEndpointAuthorization.mockReturnValue({
         parameters: {
           'certificate': 'mock-pem-key',
           'appClientId': 'test-app-id',
-          'url': customBaseUrl
         }
       } as any);
 


### PR DESCRIPTION
Providing a custom url, for example `api.xxx.ghe.com` still tries to connect to `api.github.com`.

Update the method for retrieving the base URL in the run task to ensure it uses the correct endpoint URL.