### PR TITLE
Fix: If an app was installed in more than one enterprise getting ent installation token might fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ steps:
 | appClientId | No* | The GitHub App ID (required if not using service connection) |
 | certificate | No* | The PEM certificate content (required if not using service connection) |
 | certificateFile | No | Alternative to certificate - filename containing the PEM content |
-| permissions | No | JSON object to restrict token permissions. Format: {"contents":"read","issues":"write",.....}. <br>Note: If permissions are set in the service connection, those will override any permissions specified here.<br> See permissions [Create an installation access token for an app](https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app) parameter  for full list of permissions |
+| permissions | No | JSON object to restrict token permissions. Format: {"contents":"read","issues":"write",.....}. <br>Note: If permissions are set in the service connection, those will override any permissions specified here.<br> See permissions [Create an installation access token for an app](https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#create-an-installation-access-token-for-an-app) parameter  for full list of permissions |
 | skipTokenRevoke | No | If true, the token will not be automatically revoked at the end of the job |
 
 *Required if githubAppConnection is not specified
@@ -114,7 +114,7 @@ steps:
     githubAppConnection: 'MyGitHubAppConnection'
 - bash: |
     gh api \
-    --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+    --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2026-03-10" \
     /repos/MyOrg/myRepo/issues \
     -f "title=Found a bug" -f "body=I'm having a problem with this."
   displayName: 'Create issue using GitHub CLI'
@@ -203,7 +203,7 @@ steps:
     owner: 'my-enterprise'  # Enterprise slug/name (required for enterprise)
 - bash: |
     gh api \
-    --method GET -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+    --method GET -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2026-03-10" \
     /enterprises/my-enterprise
   displayName: 'Access enterprise using GitHub CLI'
   env:
@@ -256,8 +256,6 @@ Common issues and solutions:
    - Cannot use `repositories` parameter with enterprise account type (tokens are enterprise-scoped)
    - Cannot use `forceRepoScope` in service connections with enterprise account type
    - The `owner` parameter is mandatory for enterprise account type
-8. **Rate limiting during installation lookup**: Enterprise installations use pagination which may hit rate limits with many installations. The task automatically handles rate limiting by waiting if the reset time is within 5 minutes.
-
 ### Account Type Differences
 
 | Feature | Organization | User | Enterprise |
@@ -265,7 +263,7 @@ Common issues and solutions:
 | Repository scoping | ✅ Supported | ✅ Supported | ❌ Not supported |
 | forceRepoScope | ✅ Supported | ✅ Supported | ❌ Not supported |
 | Owner parameter | Optional* | Optional* | **Required** |
-| Direct API lookup | ✅ Yes | ✅ Yes | ❌ Uses pagination workaround |
+| Direct API lookup | ✅ Yes | ✅ Yes | ✅ Yes |
 
 *Owner is optional for org/user if using GitHub repository provider (auto-extracted from Build.Repository.Name)
 

--- a/create-github-app-token/src/core/github-service.ts
+++ b/create-github-app-token/src/core/github-service.ts
@@ -59,6 +59,8 @@ export class GitHubService {
      * - https://docs.github.com/en/enterprise-cloud@latest/rest/apps/apps?apiVersion=2026-03-10#get-an-enterprise-installation-for-the-authenticated-app
      * 
      * @param jwtToken - The JSON Web Token (JWT) used for authentication with the GitHub API.
+     * @param _appClientId - Unused. The GitHub App client (or app) id is kept only to preserve the method signature
+     *                       for existing callers, since the installation lookup is fully driven by the JWT and owner.
      * @param owner - The owner of the repository, organization, or enterprise (username, organization name, or enterprise slug).
      * @param accountType - The type of account: 'org', 'user', or 'enterprise'.
      * @param repositories - An optional array of repository names to narrow down the installation ID retrieval.
@@ -124,7 +126,7 @@ export class GitHubService {
             this.dumpHeaders(err.response?.headers);
 
             let message = '';
-            if (err.status === 404) {
+            if (err.response?.status === 404) {
                 let targetType = 'account';
                 if (accountType.toLowerCase() === constants.ACCOUNT_TYPE_ORG) {
                     targetType = 'Organization';

--- a/create-github-app-token/src/core/github-service.ts
+++ b/create-github-app-token/src/core/github-service.ts
@@ -59,8 +59,6 @@ export class GitHubService {
      * - https://docs.github.com/en/enterprise-cloud@latest/rest/apps/apps?apiVersion=2026-03-10#get-an-enterprise-installation-for-the-authenticated-app
      * 
      * @param jwtToken - The JSON Web Token (JWT) used for authentication with the GitHub API.
-     * @param _appClientId - Unused. The GitHub App client (or app) id is kept only to preserve the method signature
-     *                       for existing callers, since the installation lookup is fully driven by the JWT and owner.
      * @param owner - The owner of the repository, organization, or enterprise (username, organization name, or enterprise slug).
      * @param accountType - The type of account: 'org', 'user', or 'enterprise'.
      * @param repositories - An optional array of repository names to narrow down the installation ID retrieval.
@@ -68,7 +66,7 @@ export class GitHubService {
      * @returns A promise that resolves to the installation ID of the GitHub App.
      * @throws An error if the repository name is invalid or if the API request fails.
      */
-    async getInstallationId(jwtToken: string, _appClientId: string, owner: string, accountType: string, repositories: string[] = []): Promise<number> {
+    async getInstallationId(jwtToken: string, owner: string, accountType: string, repositories: string[] = []): Promise<number> {
         let url = undefined
         let groupName = '';
         let id = 0;

--- a/create-github-app-token/src/core/github-service.ts
+++ b/create-github-app-token/src/core/github-service.ts
@@ -22,7 +22,8 @@ export class GitHubService {
 
         const axiosOptions: any = {
             headers: {
-                'Accept': 'application/vnd.github.v3+json',
+                'Accept': 'application/vnd.github+json',
+                'X-GitHub-Api-Version': constants.API_VERSION,
                 'User-Agent': `${USER_AGENT}/${VERSION}`
             }
         };
@@ -52,10 +53,10 @@ export class GitHubService {
      *
      * APIs:
      * 
-     * - https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-a-user-installation-for-the-authenticated-app
-     * - https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-organization-installation-for-the-authenticated-app
-     * - https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-a-repository-installation-for-the-authenticated-app
-     * - https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#list-installations-for-the-authenticated-app (for enterprise installations)
+     * - https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#get-a-user-installation-for-the-authenticated-app
+     * - https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#get-an-organization-installation-for-the-authenticated-app
+     * - https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#get-a-repository-installation-for-the-authenticated-app
+     * - https://docs.github.com/en/enterprise-cloud@latest/rest/apps/apps?apiVersion=2026-03-10#get-an-enterprise-installation-for-the-authenticated-app
      * 
      * @param jwtToken - The JSON Web Token (JWT) used for authentication with the GitHub API.
      * @param owner - The owner of the repository, organization, or enterprise (username, organization name, or enterprise slug).
@@ -65,7 +66,7 @@ export class GitHubService {
      * @returns A promise that resolves to the installation ID of the GitHub App.
      * @throws An error if the repository name is invalid or if the API request fails.
      */
-    async getInstallationId(jwtToken: string, appClientId: string, owner: string, accountType: string, repositories: string[] = []): Promise<number> {
+    async getInstallationId(jwtToken: string, _appClientId: string, owner: string, accountType: string, repositories: string[] = []): Promise<number> {
         let url = undefined
         let groupName = '';
         let id = 0;
@@ -81,8 +82,8 @@ export class GitHubService {
                     throw new Error(`Invalid repository name format: ${repo}. It can only contain ASCII letters, digits, and the characters ., -, and _`);
                 }
             } else if (accountType.toLowerCase() === constants.ACCOUNT_TYPE_ENTERPRISE) {
-                // Enterprise installations require pagination through all installations
-                return await this.getEnterpriseInstallationId(jwtToken, appClientId);
+                groupName = `##[group]Get Installation ID for enterprise ${owner}`;
+                url = `${this.baseUrl}/enterprises/${owner}/installation`;
             } else if (accountType.toLowerCase() === constants.ACCOUNT_TYPE_ORG) {
                 groupName = `##[group]Get Installation ID for organization ${owner}`;
                 url = `${this.baseUrl}/orgs/${owner}/installation`;
@@ -142,117 +143,9 @@ export class GitHubService {
     }
 
     /**
-     * Gets the installation ID for an enterprise installation by listing all installations
-     * and filtering for enterprise type. Handles pagination automatically.
-     * 
-     * Note: This is a workaround since there is no direct API to get the installation ID 
-     * for enterprise installations (unlike organizations and repositories).
-     * 
-     * API: https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#list-installations-for-the-authenticated-app
-     * 
-     * @param jwtToken - The JWT token for authentication
-     * @param appIdOrClientId - GitHub App ID or Client ID to match against
-     * @returns Promise<number> - The installation ID
-     * @throws Error if no matching app installation found for enterprises, or API errors
-     */
-    async getEnterpriseInstallationId(jwtToken: string, appIdOrClientId: string): Promise<number> {
-        const groupName = `##[group]Get Installation ID for enterprise app ${appIdOrClientId}`;
-        console.log(`##[group]${groupName}`);
-        console.log('Searching for enterprise installation across all app installations (workaround - no direct API available)');
-
-        let page = 1;
-        const perPage = 100; // Maximum allowed by GitHub API
-        
-        try {
-            while (true) {
-                const url = `${this.baseUrl}/app/installations?per_page=${perPage}&page=${page}`;
-                tl.debug(`Installation list request URL: ${url} (page ${page})`);
-
-                const response = await this.client.get(url, {
-                    headers: {
-                        'Authorization': `Bearer ${jwtToken}`
-                    }
-                });
-
-                this.dumpHeaders(response.headers);
-                tl.debug(`Response payload (page ${page}): ${JSON.stringify(response.data)}`);
-
-                const installations = response.data;
-                tl.debug(`Processing page ${page} of installations (${installations.length} installations)`);
-
-                // Find matching installation by app ID or app client ID
-                const matchingInstallation = installations.find((installation: any) => 
-                    installation.target_type === 'Enterprise' &&
-                    ( 
-                        installation.app_id?.toString() === appIdOrClientId ||
-                        installation.client_id === appIdOrClientId
-                    )
-                );
-
-                if (matchingInstallation) {
-                    console.log(`Found enterprise installation for app ID/client ID '${appIdOrClientId}' on page ${page}`);
-                    const installationId = matchingInstallation.id;
-
-                    tl.debug(`Enterprise installation found: ${matchingInstallation.account.name} (install ID: ${installationId})`);
-                    tl.debug(`Installation app slug: ${matchingInstallation.app_slug || 'N/A'}`);
-                    tl.debug(`Installation app name: ${matchingInstallation.app_name || 'N/A'}`);
-                    
-                    return installationId;
-                }
-
-                // Check if we've reached the end of results using GitHub's pagination headers
-                const linkHeader = response.headers['link'];
-                if (!linkHeader || !linkHeader.includes('rel="next"')) {
-                    console.log(`No 'next' link header found. Reached end of installations (page ${page}).`);
-                    break;
-                }
-
-                // Check rate limiting and wait if necessary
-                const rateLimitRemaining = parseInt(response.headers['x-ratelimit-remaining'] || '0');
-                const rateLimitReset = parseInt(response.headers['x-ratelimit-reset'] || '0');
-                const currentTime = Math.floor(Date.now() / 1000);
-                
-                if (rateLimitRemaining === 0 && (rateLimitReset - currentTime) <= 300) {
-                    const waitTime = (rateLimitReset - currentTime) + 10; // Add 10 seconds buffer
-                    console.log(`Rate limit approaching. Waiting ${waitTime} seconds before next request.`);
-                    await new Promise(resolve => setTimeout(resolve, waitTime * 1000));
-                } else if (rateLimitRemaining === 0) {
-                    const resetTime = new Date(rateLimitReset * 1000).toISOString();
-                    throw new Error(`GitHub API rate limit exceeded. Reset time: ${resetTime}. Please try again later.`);
-                }
-
-                page++;
-            }
-
-            // If we reach here, the enterprise installation was not found
-            throw new Error(`GitHub App installation not found for app ID/client ID '${appIdOrClientId}'. Please verify the app ID/client ID and enterprise installation.`);
-
-        } catch (err: any) {
-            let message = '';
-            if (err.response && err.response.status === 401) {
-                message = `GitHub App JWT authentication failed. Please verify the app credentials.`;
-            } else if (err.response && err.response.status === 403) {
-                message = `GitHub App does not have permission to list installations. Please verify the app permissions.`;
-            } else if (err.message.includes('rate limit') || err.message.includes('Rate limit')) {
-                throw err; // Re-throw rate limit errors as-is
-            } else {
-                message = err.message || `Failed to get enterprise installation ID: ${err}`;
-            }
-            
-            if (message !== err.message) {
-                throw new Error(message);
-            } else {
-                throw err;
-            }
-        } finally {
-            console.log('##[endgroup]')
-        }
-    }
-
-    /**
      * Generates an installation token for a GitHub App installation.
      * 
-     * API: https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app
+     * API: https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#create-an-installation-access-token-for-an-app
      *
      * @param jwtToken - The JSON Web Token (JWT) used for authenticating the request.
      * @param installationId - The ID of the GitHub App installation for which the token is being created.

--- a/create-github-app-token/src/tasks/run.ts
+++ b/create-github-app-token/src/tasks/run.ts
@@ -193,7 +193,7 @@ async function run() {
       repositories = repositoriesList.split(',').map(repo => repo.trim());
     }
 
-    const installationId = await githubService.getInstallationId(jwtToken, appClientId, owner, accountType, repositories);
+    const installationId = await githubService.getInstallationId(jwtToken, owner, accountType, repositories);
     console.log(`Found installation ID: ${installationId}`);
 
     const { token, expiresAt } = await githubService.getInstallationToken(jwtToken, installationId, repositories, permissions);

--- a/create-github-app-token/src/utils/constants.ts
+++ b/create-github-app-token/src/utils/constants.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_API_URL = 'https://api.github.com';
+export const API_VERSION = '2026-03-10';
 export const JWT_EXPIRATION = 10 * 60; // 10 minutes in seconds (max is 10 minutes)
 export const JWT_CLOCK_DRIFT_SECONDS = 60;
 
@@ -11,4 +12,3 @@ export const BASE_URL_TASK_VARNAME = 'baseUrl';
 export const ACCOUNT_TYPE_USER = 'user';
 export const ACCOUNT_TYPE_ORG = 'org';
 export const ACCOUNT_TYPE_ENTERPRISE = 'enterprise';
-

--- a/create-github-app-token/test/core/github-service.test.ts
+++ b/create-github-app-token/test/core/github-service.test.ts
@@ -107,7 +107,7 @@ mockprivatekeydata
           .reply(200, mockInstallationResponse);
 
         const service = new GitHubService(baseUrl);
-        const result = await service.getInstallationId(mockJwtToken, 'test-app-id', owner, 'org');
+        const result = await service.getInstallationId(mockJwtToken, owner, 'org');
 
         expect(result).toBe(installationId);
       });
@@ -120,7 +120,7 @@ mockprivatekeydata
         const service = new GitHubService(baseUrl);
         
         await expect(
-          service.getInstallationId(mockJwtToken, 'test-app-id', owner, 'org')
+          service.getInstallationId(mockJwtToken, owner, 'org')
         ).rejects.toThrow(`GitHub App not found for Organization ${owner}. Please verify the installation.`);
       });
     });
@@ -132,7 +132,7 @@ mockprivatekeydata
           .reply(200, mockInstallationResponse);
 
         const service = new GitHubService(baseUrl);
-        const result = await service.getInstallationId(mockJwtToken, 'test-app-id', user, 'user');
+        const result = await service.getInstallationId(mockJwtToken, user, 'user');
 
         expect(result).toBe(installationId);
       });
@@ -145,7 +145,7 @@ mockprivatekeydata
         const service = new GitHubService(baseUrl);
         
         await expect(
-          service.getInstallationId(mockJwtToken, 'test-app-id', owner, 'user')
+          service.getInstallationId(mockJwtToken, owner, 'user')
         ).rejects.toThrow(`GitHub App not found for account ${owner}. Please verify the installation.`);
       });
     });
@@ -159,7 +159,7 @@ mockprivatekeydata
           .reply(200, mockInstallationResponse);
 
         const service = new GitHubService(baseUrl);
-        const result = await service.getInstallationId(mockJwtToken, 'test-app-id', owner, "org", [repo]);
+        const result = await service.getInstallationId(mockJwtToken, owner, "org", [repo]);
 
         expect(result).toBe(installationId);
       });
@@ -169,7 +169,7 @@ mockprivatekeydata
         const service = new GitHubService(baseUrl);
         
         await expect(
-          service.getInstallationId(mockJwtToken, 'test-app-id', owner, "org", [invalidRepo])
+          service.getInstallationId(mockJwtToken, owner, "org", [invalidRepo])
         ).rejects.toThrow(`Invalid repository name format: ${invalidRepo}. It can only contain ASCII letters, digits, and the characters ., -, and _`);
       });
 
@@ -181,7 +181,7 @@ mockprivatekeydata
         const service = new GitHubService(baseUrl);
         
         await expect(
-          service.getInstallationId(mockJwtToken, 'test-app-id', owner, "org", [repo])
+          service.getInstallationId(mockJwtToken, owner, "org", [repo])
         ).rejects.toThrow(`GitHub App not found for Organization ${owner}. Please verify the installation and repository access.`);
       });
 
@@ -193,7 +193,7 @@ mockprivatekeydata
         const service = new GitHubService(baseUrl);
         
         await expect(
-          service.getInstallationId(mockJwtToken, 'test-app-id', owner, 'enterprise', [repo])
+          service.getInstallationId(mockJwtToken, owner, 'enterprise', [repo])
         ).rejects.toThrow(`GitHub App not found for Enterprise ${owner}. Please verify the installation and repository access.`);
       });
     });
@@ -206,7 +206,7 @@ mockprivatekeydata
       const service = new GitHubService(baseUrl);
       
       await expect(
-        service.getInstallationId(mockJwtToken, 'test-app-id', owner, "org")
+        service.getInstallationId(mockJwtToken, owner, "org")
       ).rejects.toThrow('Failed to get installation ID:');
     });
 
@@ -234,7 +234,7 @@ mockprivatekeydata
           .reply(200, mockEnterpriseInstallation);
 
         const service = new GitHubService(baseUrl);
-        const result = await service.getInstallationId(mockJwtToken, 'test-app-id', enterprise, 'enterprise');
+        const result = await service.getInstallationId(mockJwtToken, enterprise, 'enterprise');
 
         expect(result).toBe(installationId);
       });
@@ -247,7 +247,7 @@ mockprivatekeydata
         const service = new GitHubService(baseUrl);
 
         await expect(
-          service.getInstallationId(mockJwtToken, 'test-app-id', enterprise, 'enterprise')
+          service.getInstallationId(mockJwtToken, enterprise, 'enterprise')
         ).rejects.toThrow(`GitHub App not found for Enterprise ${enterprise}. Please verify the installation.`);
       });
     });
@@ -475,7 +475,7 @@ mockprivatekeydata
         });
 
       const service = new GitHubService(baseUrl);
-      await service.getInstallationId(mockJwtToken, 'test-app-id', 'test-org', 'org');
+      await service.getInstallationId(mockJwtToken, 'test-org', 'org');
 
       expect(scope.isDone()).toBe(true);
     });
@@ -495,7 +495,7 @@ mockprivatekeydata
         });
 
       const service = new GitHubService(baseUrl);
-      await service.getInstallationId(mockJwtToken, 'test-app-id', 'test-org', 'org');
+      await service.getInstallationId(mockJwtToken, 'test-org', 'org');
 
       expect(scope.isDone()).toBe(true);
     });
@@ -541,7 +541,6 @@ mockprivatekeydata
       // Get installation ID using first repository
       const actualInstallationId = await service.getInstallationId(
         jwtToken, 
-        'test-app-id',
         owner, 
         'org', 
         [repositories[0]]
@@ -604,7 +603,7 @@ mockprivatekeydata
           }
         );
 
-      const result = await service.getInstallationId('jwt-token', 'test-app-id', owner, "org");
+      const result = await service.getInstallationId('jwt-token', owner, "org");
       expect(result).toBe(12345);
       
       // Headers should be logged in debug mode (tested in main GitHubService tests)
@@ -632,7 +631,7 @@ mockprivatekeydata
           }
         );
 
-      const result = await service.getInstallationId('jwt-token', 'test-app-id', owner, 'org');
+      const result = await service.getInstallationId('jwt-token', owner, 'org');
       expect(result).toBe(12345);
       expect(mockedTl.debug).toHaveBeenCalledWith(expect.stringContaining('Header:'));
     });
@@ -650,7 +649,7 @@ mockprivatekeydata
           permissions: {}
         });
 
-      const result = await service.getInstallationId('jwt-token', 'test-app-id', owner, "org");
+      const result = await service.getInstallationId('jwt-token', owner, "org");
       expect(result).toBe(12345);
     });
 
@@ -673,7 +672,7 @@ mockprivatekeydata
           target_type: 'Organization'
         });
 
-      const result = await service.getInstallationId('jwt-token', 'test-app-id', owner, "org");
+      const result = await service.getInstallationId('jwt-token', owner, "org");
       expect(result).toBe(12345);
     });
   });

--- a/create-github-app-token/test/core/github-service.test.ts
+++ b/create-github-app-token/test/core/github-service.test.ts
@@ -216,7 +216,7 @@ mockprivatekeydata
         id: installationId,
         target_type: 'Enterprise',
         account: {
-          login: enterprise
+          slug: enterprise
         },
         app_id: 2345,
         client_id: 'test-app-id',
@@ -226,22 +226,11 @@ mockprivatekeydata
         },
       };
 
-      it('should get installation ID for enterprise by app client id', async () => {
+      it('should get the installation ID from the enterprise endpoint', async () => {
         nock(baseUrl)
-          .get('/app/installations?per_page=100&page=1')
-          .reply(200, [
-            {
-              id: 11111,
-              target_type: 'Organization',
-              account: { login: 'some-org' }
-            },
-            mockEnterpriseInstallation,
-            {
-              id: 22222,
-              target_type: 'User',
-              account: { login: 'some-user' }
-            }
-          ]);
+          .get(`/enterprises/${enterprise}/installation`)
+          .matchHeader('x-github-api-version', constants.API_VERSION)
+          .reply(200, mockEnterpriseInstallation);
 
         const service = new GitHubService(baseUrl);
         const result = await service.getInstallationId(mockJwtToken, 'test-app-id', enterprise, 'enterprise');
@@ -249,223 +238,16 @@ mockprivatekeydata
         expect(result).toBe(installationId);
       });
 
-      it('should get installation ID for enterprise by app id', async () => {
+      it('should handle an enterprise installation that is not found', async () => {
         nock(baseUrl)
-          .get('/app/installations?per_page=100&page=1')
-          .reply(200, [
-            {
-              id: 11111,
-              target_type: 'Organization',
-              account: { login: 'some-org' }
-            },
-            mockEnterpriseInstallation,
-            {
-              id: 22222,
-              target_type: 'User',
-              account: { login: 'some-user' }
-            }
-          ]);
+          .get(`/enterprises/${enterprise}/installation`)
+          .reply(404, { message: 'Not Found' });
 
         const service = new GitHubService(baseUrl);
-        const result = await service.getInstallationId(mockJwtToken, '2345', enterprise, 'enterprise');
 
-        expect(result).toBe(installationId);
-      });
-
-      it('should handle multiple pages when searching for enterprise', async () => {
-        // First page with no enterprise installations
-        const page1Scope = nock(baseUrl)
-          .get('/app/installations?per_page=100&page=1')
-          .reply(200, Array(100).fill({
-              id: 11111,
-              target_type: 'Organization',
-              account: { login: 'some-org' }
-            }), {
-              'link': '<https://api.github.com/app/installations?per_page=100&page=2>; rel="next"'
-            }
-        );
-
-        // Second page with enterprise installation
-        const page2Scope = nock(baseUrl)
-          .get('/app/installations?per_page=100&page=2')
-          .reply(
-            200,
-            [
-              mockEnterpriseInstallation,
-              {
-                id: 22222,
-                target_type: 'User',
-                account: { login: 'some-user' }
-              }
-            ],
-            {
-              'link': '<https://api.github.com/app/installations?per_page=100&page=2>; rel="last"'
-            }
-          );
-
-        const service = new GitHubService(baseUrl);
-        const result = await service.getInstallationId(mockJwtToken, 'test-app-id', enterprise, 'enterprise');
-
-        expect(result).toBe(installationId);
-        expect(page1Scope.isDone()).toBe(true);
-        expect(page2Scope.isDone()).toBe(true);
-      });
-
-      it('should throw error when no enterprise installations found', async () => {
-        nock(baseUrl)
-          .get('/app/installations?per_page=100&page=1')
-          .reply(200, [
-            {
-              id: 11111,
-              target_type: 'Organization',
-              account: { login: 'some-org' }
-            },
-            {
-              id: 22222,
-              target_type: 'User',
-              account: { login: 'some-user' }
-            }
-          ]);
-
-        const service = new GitHubService(baseUrl);
-        
         await expect(
           service.getInstallationId(mockJwtToken, 'test-app-id', enterprise, 'enterprise')
-        ).rejects.toThrow(`GitHub App installation not found for app ID/client ID 'test-app-id'. Please verify the app ID/client ID and enterprise installation.`);
-      });
-
-      it('should throw error when specific enterprise not found', async () => {
-        nock(baseUrl)
-          .get('/app/installations?per_page=100&page=1')
-          .reply(200, [
-            {
-              id: 33333,
-              target_type: 'Enterprise',
-              account: { login: 'other-enterprise' },
-              app_id: 'different-app-id',
-              client_id: 'different-client-id'
-            }
-          ]);
-
-        const service = new GitHubService(baseUrl);
-        
-        await expect(
-          service.getInstallationId(mockJwtToken, 'test-app-id', enterprise, 'enterprise')
-        ).rejects.toThrow(`GitHub App installation not found for app ID/client ID 'test-app-id'. Please verify the app ID/client ID and enterprise installation.`);
-      });
-
-      it('should handle rate limiting during pagination', async () => {
-        // First request hits low rate limit but still works
-        nock(baseUrl)
-          .get('/app/installations?per_page=100&page=1')
-          .reply(200, Array(100).fill({
-            id: 11111,
-            target_type: 'Organization',
-            account: { login: 'some-org' }
-          }), {
-            'x-ratelimit-remaining': '0',
-            'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 120), // Reset in 2 minutes (within 5 min threshold)
-            'link': '<https://api.github.com/app/installations?per_page=100&page=2>; rel="next"'
-          });
-
-        // Second request should succeed after waiting
-        nock(baseUrl)
-          .get('/app/installations?per_page=100&page=2')
-          .reply(200, [mockEnterpriseInstallation]);
-
-        const service = new GitHubService(baseUrl);
-        
-        // Mock setTimeout to avoid actually waiting
-        const originalSetTimeout = global.setTimeout;
-        const mockSetTimeout = jest.fn((callback: Function) => {
-          callback();
-          return {} as any;
-        }) as any;
-        global.setTimeout = mockSetTimeout;
-
-        try {
-          const result = await service.getInstallationId(mockJwtToken, 'test-app-id', enterprise, 'enterprise');
-          expect(result).toBe(installationId);
-          expect(mockSetTimeout).toHaveBeenCalled();
-        } finally {
-          global.setTimeout = originalSetTimeout;
-        }
-      }, 15000); // Increased timeout
-
-      it('should throw error when rate limit exceeded', async () => {
-        // First page has some installations but hits rate limit
-        nock(baseUrl)
-          .get('/app/installations?per_page=100&page=1')
-          .reply(200, Array(100).fill({
-            id: 11111,
-            target_type: 'Organization',
-            account: { login: 'some-org' }
-          }), {
-            'x-ratelimit-remaining': '0',
-            'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 3600), // Reset in 1 hour
-            'link': '<https://api.github.com/app/installations?per_page=100&page=2>; rel="next"'
-          });
-
-        const service = new GitHubService(baseUrl);
-        
-        await expect(
-          service.getEnterpriseInstallationId(mockJwtToken, 'test-app-id')
-        ).rejects.toThrow('GitHub API rate limit exceeded');
-      });
-
-      it('should handle 401 authentication error', async () => {
-        nock(baseUrl)
-          .get('/app/installations?per_page=100&page=1')
-          .reply(401, { message: 'Unauthorized' });
-
-        const service = new GitHubService(baseUrl);
-        
-        await expect(
-          service.getInstallationId(mockJwtToken, 'test-app-id', enterprise, 'enterprise')
-        ).rejects.toThrow('GitHub App JWT authentication failed. Please verify the app credentials.');
-      });
-
-      it('should handle 403 permission error', async () => {
-        nock(baseUrl)
-          .get('/app/installations?per_page=100&page=1')
-          .reply(403, { message: 'Forbidden' });
-
-        const service = new GitHubService(baseUrl);
-        
-        await expect(
-          service.getInstallationId(mockJwtToken, 'test-app-id', enterprise, 'enterprise')
-        ).rejects.toThrow('GitHub App does not have permission to list installations. Please verify the app permissions.');
-      });
-
-      it('should handle multiple enterprise installations with warning', async () => {
-        const mockInstallations = [
-          {
-            id: 55555,
-            target_type: 'Enterprise',
-            account: { login: enterprise },
-            app_id: 'test-app-id',
-            client_id: 'test-app-id',
-            permissions: { contents: 'read' }
-          },
-          {
-            id: 66666,
-            target_type: 'Enterprise',
-            account: { login: enterprise }, // Same enterprise, multiple installations
-            app_id: 'other-app-id',
-            client_id: 'other-app-id',
-            permissions: { contents: 'write' }
-          }
-        ];
-
-        nock(baseUrl)
-          .get('/app/installations?per_page=100&page=1')
-          .reply(200, mockInstallations);
-
-        const service = new GitHubService(baseUrl);
-        const result = await service.getInstallationId(mockJwtToken, 'test-app-id', enterprise, 'enterprise');
-
-        // Should return the first matching installation
-        expect(result).toBe(55555);
+        ).rejects.toThrow(`GitHub App not found for Enterprise ${enterprise}. Please verify the installation.`);
       });
     });
   });

--- a/create-github-app-token/test/core/github-service.test.ts
+++ b/create-github-app-token/test/core/github-service.test.ts
@@ -1,5 +1,6 @@
 import { GitHubService } from '../../src/core/github-service';
 import { ProxyConfig } from '../../src/core/proxy-config';
+import * as constants from '../../src/utils/constants';
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as jwt from 'jsonwebtoken';
 import nock from 'nock';

--- a/create-github-app-token/test/tasks/run.test.ts
+++ b/create-github-app-token/test/tasks/run.test.ts
@@ -104,7 +104,7 @@ describe('run task logic', () => {
 
       expect(MockedGitHubService).toHaveBeenCalledWith('https://api.github.com/', { proxy: mockProxyConfig });
       expect(mockGitHubService.generateJWT).toHaveBeenCalledWith('test-app-id', 'mock-pem-key');
-      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-app-id', 'test-org', "org", []);
+      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-org', "org", []);
       expect(mockGitHubService.getInstallationToken).toHaveBeenCalledWith('mock.jwt.token', 12345, [], undefined);
       
       // Verify output variables are set
@@ -131,7 +131,7 @@ describe('run task logic', () => {
 
       // Should generate JWT and proceed through the flow
       expect(mockGitHubService.generateJWT).toHaveBeenCalledWith('test-app-id', 'mock-pem-key');
-      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-app-id', 'test-org', "org", []);
+      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-org', "org", []);
       expect(mockGitHubService.getInstallationToken).toHaveBeenCalledWith('mock.jwt.token', 12345, [], undefined);
 
       // Should set output variables
@@ -168,7 +168,7 @@ describe('run task logic', () => {
       expect(mockGitHubService.generateJWT).toHaveBeenCalledWith('test-app-id', mockPemContent);
 
       // Should proceed through the rest of the flow and set output variables
-      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-app-id', 'test-org', "org", []);
+      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-org', "org", []);
       expect(mockGitHubService.getInstallationToken).toHaveBeenCalledWith('mock.jwt.token', 12345, [], undefined);
 
       expect(mockedTl.setVariable).toHaveBeenCalledWith(constants.INSTALLATIONID_OUTPUT_VARNAME, '12345', false);
@@ -207,7 +207,7 @@ describe('run task logic', () => {
       await run();
 
       // Verify the extracted owner is used correctly
-      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-app-id', 'auto-owner', "org", []);
+      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'auto-owner', "org", []);
       expect(mockGitHubService.getInstallationToken).toHaveBeenCalledWith('mock.jwt.token', 12345, [], undefined);
       
       // Verify successful completion with output variables set
@@ -243,7 +243,7 @@ describe('run task logic', () => {
       await run();
 
       // Verify repositories are parsed and trimmed correctly
-      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-app-id', 'test-org', "org", ['repo1', 'repo2', 'repo3']);
+      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-org', "org", ['repo1', 'repo2', 'repo3']);
       expect(mockGitHubService.getInstallationToken).toHaveBeenCalledWith('mock.jwt.token', 12345, ['repo1', 'repo2', 'repo3'], undefined);
       
       // Verify successful completion with output variables set
@@ -553,7 +553,7 @@ describe('run task logic', () => {
 
       // Should succeed with enterprise account type
       expect(mockGitHubService.generateJWT).toHaveBeenCalledWith('test-app-id', 'mock-pem-key');
-      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-app-id', 'my-enterprise', 'enterprise', []);
+      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'my-enterprise', 'enterprise', []);
       expect(mockGitHubService.getInstallationToken).toHaveBeenCalledWith('mock.jwt.token', 12345, [], undefined);
       
       // Verify output variables are set
@@ -685,7 +685,7 @@ describe('run task logic', () => {
 
       // Should succeed and call GitHub service with enterprise account type
       expect(mockGitHubService.generateJWT).toHaveBeenCalledWith('test-app-id', 'mock-pem-key');
-      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-app-id', 'my-enterprise', 'enterprise', []);
+      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'my-enterprise', 'enterprise', []);
       expect(mockGitHubService.getInstallationToken).toHaveBeenCalledWith('mock.jwt.token', 12345, [], undefined);
       
       // Verify output variables are set
@@ -724,7 +724,7 @@ describe('run task logic', () => {
 
       // Should succeed and pass permissions to getInstallationToken
       expect(mockGitHubService.generateJWT).toHaveBeenCalledWith('test-app-id', 'mock-pem-key');
-      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-app-id', 'my-enterprise', 'enterprise', []);
+      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'my-enterprise', 'enterprise', []);
       expect(mockGitHubService.getInstallationToken).toHaveBeenCalledWith(
         'mock.jwt.token',
         12345,
@@ -822,7 +822,7 @@ describe('run task logic', () => {
       await run();
 
       // Should use forced owner and repo from Build.Repository.Name
-      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-app-id', 'force-owner', "org", ['force-repo']);
+      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'force-owner', "org", ['force-repo']);
       expect(mockGitHubService.getInstallationToken).toHaveBeenCalledWith('mock.jwt.token', 12345, ['force-repo'], undefined);
 
       // Assert that a debug message was logged about ignoring the passed repo
@@ -936,7 +936,7 @@ describe('run task logic', () => {
       expect(mockedTl.warning).toHaveBeenCalledWith('Forcing repo scope to force-repo. Ignoring repositories input different-repo');
       
       // Should use forced repo from Build.Repository.Name, not the input
-      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-app-id', 'force-owner', "org", ['force-repo']);
+      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'force-owner', "org", ['force-repo']);
       expect(mockGitHubService.getInstallationToken).toHaveBeenCalledWith('mock.jwt.token', 12345, ['force-repo'], undefined);
     });
 
@@ -979,7 +979,7 @@ describe('run task logic', () => {
       expect(mockedTl.warning).toHaveBeenCalledWith('Forcing repo scope to force-repo, even though no repositories were provided');
       
       // Should use forced repo
-      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-app-id', 'force-owner', "org", ['force-repo']);
+      expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'force-owner', "org", ['force-repo']);
       expect(mockGitHubService.getInstallationToken).toHaveBeenCalledWith('mock.jwt.token', 12345, ['force-repo'], undefined);
     });
   });

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -92,7 +92,7 @@
                             {
                                 "id": "limitPermissions",
                                 "name": "Limit Token Permissions",
-                                "description": "Optional JSON object to restrict token permissions. If empty will use app permissions or permissions set at task level. If provided, this will override any permissions set in the task input Format: {\"permission\":\"accesstype\"} EG: {\"contents\":\"read\",\"issues\":\"write\"}. see permissions parameter https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app for full list of permissions.",
+                                "description": "Optional JSON object to restrict token permissions. If empty will use app permissions or permissions set at task level. If provided, this will override any permissions set in the task input Format: {\"permission\":\"accesstype\"} EG: {\"contents\":\"read\",\"issues\":\"write\"}. see permissions parameter https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#create-an-installation-access-token-for-an-app for full list of permissions.",
                                 "inputMode": "textarea",
                                 "isConfidential": false,
                                 "validation": {


### PR DESCRIPTION
Use direct API lookup for enterprise installations

Replace the paginated enterprise installation workaround with the dedicated GET /enterprises/{enterprise}/installation endpoint so the requested enterprise slug always determines the installation (this API was not originally available, thus the workaround)

Upgrade all GitHub REST API calls to version 2026-03-10 and update the default Accept header to application/vnd.github+json. Remove obsolete pagination logic and update tests and documentation for the direct lookup.


closes #65 