### PR TITLE
feat: support custom API URLs without service connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Azure Pipelines extension to create a GitHub App installation tokens that can be
 - Generates GitHub App installation tokens for API authentication
 - Supports organization-wide, user-level, or enterprise-level tokens
 - Provides multiple authentication options (service connection or direct inputs)
+- Supports GitHub.com and custom GitHub API base URLs
 - Handles proxy configurations through environment variables
 - Secure handling of private keys and credentials
 - Cross-platform compatibility
@@ -56,6 +57,7 @@ steps:
     owner: 'your-org-name'
     appClientId: 'lv2313qqwqeqweqw'        # Your GitHub App ID
     certificate: '$(pem)'       # PEM content as variable
+    apiUrl: 'https://api.tenant.ghe.com/' # Optional; defaults to GitHub.com
     repositories: 'repo1,repo2' # Optional
 ```
 
@@ -70,6 +72,7 @@ steps:
 | appClientId | No* | The GitHub App ID (required if not using service connection) |
 | certificate | No* | The PEM certificate content (required if not using service connection) |
 | certificateFile | No | Alternative to certificate - filename containing the PEM content |
+| apiUrl | No | The GitHub API base URL. Defaults to `https://api.github.com`. **Only used when `githubAppConnection` is not defined.** When a service connection is used, its API URL takes precedence. |
 | permissions | No | JSON object to restrict token permissions. Format: {"contents":"read","issues":"write",.....}. <br>Note: If permissions are set in the service connection, those will override any permissions specified here.<br> See permissions [Create an installation access token for an app](https://docs.github.com/en/rest/apps/apps?apiVersion=2026-03-10#create-an-installation-access-token-for-an-app) parameter  for full list of permissions |
 | skipTokenRevoke | No | If true, the token will not be automatically revoked at the end of the job |
 
@@ -97,7 +100,7 @@ steps:
      > Permissions can only be downgraded from what the GitHub App has. For example, if the GitHub App has "read" access to contents, you cannot request "write" access. Attempting to request higher permissions than what the GitHub App has will result in a failure to obtain the token.
    - Scope to repository. If this is set then the repositories input is ignored and the token will be scoped to the repository where the pipeline is running. For example this can be useful if install the on all or some repositories but you don't want the pipeline to access other repositories.
      - **only** works if sources repository is GitHub. If you try to use with another source it will throw an error.
-   - Optionally change the API URL if not using github.com
+    - Optionally change the API URL if not using GitHub.com. This service connection URL is always used when the task's `githubAppConnection` input is defined; the task-level `apiUrl` input is ignored.
 5. Save the connection
 
 ![Service Connection](docs/images/gh-app-service-connection.png)
@@ -133,6 +136,20 @@ steps:
     certificate: '$(githubAppPem)'  # Variable containing PEM content
     permissions: '{"contents":"read","pulls":"write","issues":"write"}'
 ```
+
+For a GitHub Enterprise Server instance, set `apiUrl` when using direct inputs:
+
+```yaml
+steps:
+- task: create-github-app-token@1
+  inputs:
+    owner: 'MyOrg'
+    appClientId: 'lv2313qqwqeqweqw'
+    certificate: '$(githubAppPem)'
+    apiUrl: 'https://github.example.com/api/v3'
+```
+
+The `apiUrl` input is only used when `githubAppConnection` is not defined. Configure the API URL on the service connection when using one.
 
 ### Repository-Scoped Token and restricted permissions
 

--- a/create-github-app-token/src/core/github-service.ts
+++ b/create-github-app-token/src/core/github-service.ts
@@ -18,7 +18,7 @@ export class GitHubService {
         if (!baseUrl) {
             throw new Error('GitHub API base URL is required');
         }
-        this.baseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+        this.baseUrl = baseUrl.replace(/\/+$/, '');
 
         const axiosOptions: any = {
             headers: {

--- a/create-github-app-token/src/tasks/run.ts
+++ b/create-github-app-token/src/tasks/run.ts
@@ -37,6 +37,10 @@ async function run() {
     const skipTokenRevoke = tl.getBoolInput('skipTokenRevoke', false);
     const permissionsInput = tl.getInput('permissions', false);
 
+    if (!connectedServiceName) {
+      baseUrl = tl.getInput('apiUrl', false)?.trim() || baseUrl;
+    }
+
     let permissions: { [key: string]: string } | undefined = undefined;
     if (permissionsInput) {
       try {
@@ -123,7 +127,6 @@ async function run() {
           repositoriesList = forcedRepo;
         }
 
-        console.log(`Base URL: ${baseUrl}`);
         console.log(`App ID from service connection: ${appClientId}`);
 
         console.log('##[endgroup]')
@@ -136,6 +139,8 @@ async function run() {
         return;
       }
     }
+
+    console.log(`Base URL: ${baseUrl}`);
 
     if (!privateKey && privateKeyInput) {
       console.log('Using private key from certificate input');

--- a/create-github-app-token/task.json
+++ b/create-github-app-token/task.json
@@ -9,8 +9,8 @@
     "author": "Tiago Pascoal",
     "version": {
         "Major": 1,
-        "Minor": 0,
-        "Patch": 8
+        "Minor": 2,
+        "Patch": 0
     },
     "instanceNameFormat": "Create GitHub App Installation Token",
     "groups": [
@@ -84,6 +84,16 @@
             "required": false,
             "helpMarkDown": "The GitHub App ID (found in the app settings)",
             "groupName": "withoutServiceConnection"
+        },
+        {
+            "name": "apiUrl",
+            "type": "string",
+            "label": "GitHub API URL",
+            "defaultValue": "https://api.github.com",
+            "required": false,
+            "helpMarkDown": "The GitHub API base URL. This input is only used when githubAppConnection is not defined.",
+            "groupName": "withoutServiceConnection",
+            "visibleRule": "githubAppConnection == ''"
         },
         {
             "name": "skipTokenRevoke",

--- a/create-github-app-token/test/core/github-service.test.ts
+++ b/create-github-app-token/test/core/github-service.test.ts
@@ -51,15 +51,44 @@ mockprivatekeydata
       expect(() => new GitHubService('')).toThrow('GitHub API base URL is required');
     });
 
-    it('should normalize base URL by removing trailing slash', () => {
-      const service = new GitHubService('https://api.github.com/');
-      expect(service).toBeInstanceOf(GitHubService);
-    });
-
     it('should create service with proxy configuration', () => {
       const proxyConfig = new ProxyConfig({ proxyUrl: 'http://proxy.example.com:8080' });
       const service = new GitHubService(baseUrl, { proxy: proxyConfig });
       expect(service).toBeInstanceOf(GitHubService);
+    });
+  });
+
+  describe.each([
+    ['without a trailing slash', 'https://github.enterprise.com/api/v3'],
+    ['with a trailing slash', 'https://github.enterprise.com/api/v3/'],
+    ['with repeated trailing slashes', 'https://github.enterprise.com/api/v3///']
+  ])('base URL normalization %s', (_scenario, overriddenBaseUrl) => {
+    it('builds every API endpoint with exactly one separating slash', async () => {
+      const normalizedBaseUrl = 'https://github.enterprise.com/api/v3';
+      const installationId = 12345;
+      const scope = nock(normalizedBaseUrl)
+        .get('/orgs/test-org/installation')
+        .reply(200, {
+          id: installationId,
+          repository_selection: 'all',
+          permissions: { contents: 'read' }
+        })
+        .post(`/app/installations/${installationId}/access_tokens`, {})
+        .reply(200, {
+          token: 'ghs_mock_installation_token',
+          expires_at: '2024-01-01T13:00:00Z',
+          repository_selection: 'all',
+          permissions: { contents: 'read' }
+        })
+        .delete('/installation/token')
+        .reply(204);
+
+      const service = new GitHubService(overriddenBaseUrl);
+      await service.getInstallationId(mockJwtToken, 'test-org', 'org');
+      await service.getInstallationToken(mockJwtToken, installationId);
+      await service.revokeInstallationToken('ghs_mock_installation_token');
+
+      expect(scope.isDone()).toBe(true);
     });
   });
 
@@ -502,12 +531,6 @@ mockprivatekeydata
   });
 
   describe('advanced integration scenarios', () => {
-    it('should handle enterprise GitHub URL normalization', () => {
-      const enterpriseUrl = 'https://github.enterprise.com/api/v3/';
-      const enterpriseService = new GitHubService(enterpriseUrl);
-      expect(enterpriseService).toBeInstanceOf(GitHubService);
-    });
-
     it('should handle multiple repository installations', async () => {
       const owner = 'test-org';
       const repositories = ['repo1', 'repo2', 'repo3'];

--- a/create-github-app-token/test/tasks/run.test.ts
+++ b/create-github-app-token/test/tasks/run.test.ts
@@ -143,6 +143,52 @@ describe('run task logic', () => {
       expect(mockedTl.setResult).not.toHaveBeenCalled();
     });
 
+    it('should use a custom API URL with direct inputs', async () => {
+      const customBaseUrl = 'https://github.enterprise.com/api/v3';
+
+      mockedTl.getInput.mockImplementation((name: string) => {
+        switch (name) {
+          case 'owner':
+            return 'test-org';
+          case 'appClientId':
+            return 'test-app-id';
+          case 'certificate':
+            return 'mock-pem-key';
+          case 'apiUrl':
+            return customBaseUrl;
+          default:
+            return '';
+        }
+      });
+
+      await run();
+
+      expect(console.log).toHaveBeenCalledWith(`Base URL: ${customBaseUrl}`);
+      expect(ProxyConfig.fromAzurePipelines).toHaveBeenCalledWith(customBaseUrl);
+      expect(MockedGitHubService).toHaveBeenCalledWith(customBaseUrl, { proxy: mockProxyConfig });
+      expect(mockedTl.setTaskVariable).toHaveBeenCalledWith(constants.BASE_URL_TASK_VARNAME, customBaseUrl);
+    });
+
+    it('should use the default API URL when the direct input is empty', async () => {
+      mockedTl.getInput.mockImplementation((name: string) => {
+        switch (name) {
+          case 'owner':
+            return 'test-org';
+          case 'appClientId':
+            return 'test-app-id';
+          case 'certificate':
+            return 'mock-pem-key';
+          default:
+            return '';
+        }
+      });
+
+      await run();
+
+      expect(MockedGitHubService).toHaveBeenCalledWith(constants.DEFAULT_API_URL, { proxy: mockProxyConfig });
+      expect(mockedTl.setTaskVariable).toHaveBeenCalledWith(constants.BASE_URL_TASK_VARNAME, constants.DEFAULT_API_URL);
+    });
+
     it('should complete successfully with certificate file', async () => {
       const mockPemContent = '-----BEGIN RSA PRIVATE KEY-----\nmock-key\n-----END RSA PRIVATE KEY-----';
       
@@ -833,6 +879,7 @@ describe('run task logic', () => {
 
     it('should handle custom base URL from service connection', async () => {
       const customBaseUrl = 'https://github.enterprise.com/api/v3';
+      const directInputBaseUrl = 'https://ignored.example.com/api/v3';
       
       mockedTl.getInput.mockImplementation((name: string) => {
         switch (name) {
@@ -840,6 +887,8 @@ describe('run task logic', () => {
             return 'test-connection';
           case 'owner':
             return 'test-org';
+          case 'apiUrl':
+            return directInputBaseUrl;
           default:
             return '';
         }
@@ -855,6 +904,8 @@ describe('run task logic', () => {
 
       await run();
 
+      expect(mockedTl.getInput).not.toHaveBeenCalledWith('apiUrl', false);
+      expect(console.log).toHaveBeenCalledWith(`Base URL: ${customBaseUrl}`);
       expect(MockedGitHubService).toHaveBeenCalledWith(customBaseUrl, { proxy: mockProxyConfig });
     });
 

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "create-github-app-token",
     "name": "GitHub App Token Generator",
-    "version": "1.0.9",
+    "version": "1.2.0",
     "publisher": "INSERT YOUR PUBLISHER HERE",
     "public": false,
     "targets": [


### PR DESCRIPTION
Overriding API url now has feature parity with service connection use, the override is only possible if the service connection is not used.

This brings URL API overriding feature parity. Previously it was only possible using service connections.

Add an optional apiUrl input for direct GitHub App credentials so GitHub Enterprise Server users can target a custom API endpoint. Default to https://api.github.com and keep the service connection URL authoritative whenever githubAppConnection is configured.

This pull request adds support for custom GitHub API base URLs (for GitHub Enterprise Server and similar) to the Azure Pipelines extension, improves base URL normalization, and updates documentation and tests accordingly. The changes ensure that the `apiUrl` input is only used when not using a service connection and that base URLs are handled robustly regardless of trailing slashes.

