### PR TITLE
feat: Expose GitHub endpoint outputs for portable CLI and API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ steps:
 | installationToken | The generated GitHub App installation token |
 | installationId | The ID of the GitHub App installation |
 | tokenExpiration | The expiration date and time of the generated token (ISO 8601 format) |
+| GitHubHost | The GitHub hostname for [`GH_HOST`](https://cli.github.com/manual/gh_help_environment), such as `github.com`, `company.ghe.com`, or `github.company.com` |
+| GitHubAPIUrl | The normalized GitHub REST API base URL without a trailing slash, suitable for API calls in scripts |
+
+The URL outputs follow GitHub's API endpoint conventions:
+
+| GitHub environment | API URL / `GitHubAPIUrl` | `GitHubHost` |
+|--------------------|--------------------------|--------------|
+| GitHub Enterprise Cloud | `https://api.github.com` | `github.com` |
+| GitHub Enterprise Cloud with data residency | `https://api.company.ghe.com` | `company.ghe.com` |
+| GitHub Enterprise Server | `https://gh.company.com/api/v3` | `gh.company.com` |
 
 ### Service Connection Setup (optional)
 
@@ -123,6 +133,7 @@ steps:
   displayName: 'Create issue using GitHub CLI'
   env:
     GH_TOKEN: $(token.installationToken)
+    GH_HOST: $(token.GitHubHost)
 ```
 
 ### Using Direct Certificate Input and restriction permissions
@@ -142,11 +153,17 @@ For a GitHub Enterprise Server instance, set `apiUrl` when using direct inputs:
 ```yaml
 steps:
 - task: create-github-app-token@1
+  name: token
   inputs:
     owner: 'MyOrg'
     appClientId: 'lv2313qqwqeqweqw'
     certificate: '$(githubAppPem)'
-    apiUrl: 'https://github.example.com/api/v3'
+    apiUrl: 'https://github.example.com/api/v3/'
+- bash: gh api /user
+  displayName: 'Call the GitHub Enterprise Server API'
+  env:
+    GH_ENTERPRISE_TOKEN: $(token.installationToken)
+    GH_HOST: $(token.GitHubHost)
 ```
 
 The `apiUrl` input is only used when `githubAppConnection` is not defined. Configure the API URL on the service connection when using one.
@@ -179,7 +196,8 @@ steps:
     githubAppConnection: 'MyGitHubAppConnection'
 
 - script: |
-    curl -H "Authorization: Bearer $(githubAuth.installationToken)" https://api.github.com/repos/MyOrg/MyRepo/issues | jq
+    curl -H "Authorization: Bearer $(githubAuth.installationToken)" \
+      "$(githubAuth.GitHubAPIUrl)/repos/MyOrg/MyRepo/issues" | jq
   displayName: 'List issues using cURL'
 ```
 
@@ -225,6 +243,7 @@ steps:
   displayName: 'Access enterprise using GitHub CLI'
   env:
     GH_TOKEN: $(enterpriseToken.installationToken)
+    GH_HOST: $(enterpriseToken.GitHubHost)
 ```
 
 ### Enterprise with Direct Certificate Input

--- a/create-github-app-token/src/core/github-service.ts
+++ b/create-github-app-token/src/core/github-service.ts
@@ -3,6 +3,7 @@ import axios, { AxiosInstance } from 'axios';
 import * as jwt from 'jsonwebtoken';
 import { ProxyConfig } from './proxy-config';
 import { validateRepositoryName } from '../utils/validation';
+import { normalizeGitHubApiUrl } from '../utils/github';
 import * as constants from '../utils/constants';
 import { VERSION, USER_AGENT } from '../utils/version';
 
@@ -18,7 +19,7 @@ export class GitHubService {
         if (!baseUrl) {
             throw new Error('GitHub API base URL is required');
         }
-        this.baseUrl = baseUrl.replace(/\/+$/, '');
+        this.baseUrl = normalizeGitHubApiUrl(baseUrl);
 
         const axiosOptions: any = {
             headers: {

--- a/create-github-app-token/src/tasks/run.ts
+++ b/create-github-app-token/src/tasks/run.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import { GitHubService } from '../core/github-service';
 import { ProxyConfig } from '../core/proxy-config';
 import * as constants from '../utils/constants';
-import { getRepoName, getOwnerName } from '../utils/github';
+import { getGitHubHost, getRepoName, getOwnerName, normalizeGitHubApiUrl } from '../utils/github';
 import { validateAccountType } from '../utils/validation';
 
 async function run() {
@@ -140,6 +140,9 @@ async function run() {
       }
     }
 
+    baseUrl = normalizeGitHubApiUrl(baseUrl);
+    const githubHost = getGitHubHost(baseUrl);
+
     console.log(`Base URL: ${baseUrl}`);
 
     if (!privateKey && privateKeyInput) {
@@ -208,6 +211,8 @@ async function run() {
     tl.setVariable(constants.INSTALLATIONID_OUTPUT_VARNAME, installationId.toString(), false);
     tl.setVariable(constants.INSTALLATION_TOKEN_OUTPUT_VARNAME, token, true); // secret
     tl.setVariable(constants.TOKEN_EXPIRATION_OUTPUT_VARNAME, expiresAt, false);
+    tl.setVariable(constants.GITHUB_HOST_OUTPUT_VARNAME, githubHost, false);
+    tl.setVariable(constants.GITHUB_API_URL_OUTPUT_VARNAME, baseUrl, false);
 
     // Save state for post job
     tl.setTaskVariable(constants.INSTALLATION_TOKEN_OUTPUT_VARNAME, token, true); // secret

--- a/create-github-app-token/src/utils/constants.ts
+++ b/create-github-app-token/src/utils/constants.ts
@@ -6,6 +6,8 @@ export const JWT_CLOCK_DRIFT_SECONDS = 60;
 export const INSTALLATIONID_OUTPUT_VARNAME = 'installationId';
 export const INSTALLATION_TOKEN_OUTPUT_VARNAME = 'installationToken';
 export const TOKEN_EXPIRATION_OUTPUT_VARNAME = 'tokenExpiration';
+export const GITHUB_HOST_OUTPUT_VARNAME = 'GitHubHost';
+export const GITHUB_API_URL_OUTPUT_VARNAME = 'GitHubAPIUrl';
 export const SKIP_TOKEN_TASK_VARNAME = 'skipTokenRevoke';
 export const BASE_URL_TASK_VARNAME = 'baseUrl';
 

--- a/create-github-app-token/src/utils/github.ts
+++ b/create-github-app-token/src/utils/github.ts
@@ -17,3 +17,21 @@ export function getRepoName(nwo: string) {
 export function getOwnerName(nwo: string) {
   return nwo.split("/")[0];
 }
+
+/**
+ * Normalizes a GitHub API base URL for use when constructing request URLs.
+ */
+export function normalizeGitHubApiUrl(baseUrl: string) {
+  return baseUrl.trim().replace(/\/+$/, '');
+}
+
+/**
+ * Derives the GitHub hostname expected by GitHub CLI from an API base URL.
+ */
+export function getGitHubHost(apiUrl: string) {
+  const apiHostname = new URL(apiUrl).hostname;
+
+  return apiHostname === 'api.github.com' || (apiHostname.startsWith('api.') && apiHostname.endsWith('.ghe.com'))
+    ? apiHostname.substring(4)
+    : apiHostname;
+}

--- a/create-github-app-token/task.json
+++ b/create-github-app-token/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 1,
         "Minor": 2,
-        "Patch": 0
+        "Patch": 1
     },
     "instanceNameFormat": "Create GitHub App Installation Token",
     "groups": [
@@ -116,6 +116,14 @@
         {
             "name": "tokenExpiration",
             "description": "The expiration date and time of the generated token (ISO 8601 format)"
+        },
+        {
+            "name": "GitHubHost",
+            "description": "The GitHub hostname for use with GitHub CLI's GH_HOST environment variable"
+        },
+        {
+            "name": "GitHubAPIUrl",
+            "description": "The normalized GitHub API base URL without a trailing slash"
         }
     ],
     "execution": {

--- a/create-github-app-token/test/tasks/run.test.ts
+++ b/create-github-app-token/test/tasks/run.test.ts
@@ -102,7 +102,7 @@ describe('run task logic', () => {
 
       await run();
 
-      expect(MockedGitHubService).toHaveBeenCalledWith('https://api.github.com/', { proxy: mockProxyConfig });
+      expect(MockedGitHubService).toHaveBeenCalledWith('https://api.github.com', { proxy: mockProxyConfig });
       expect(mockGitHubService.generateJWT).toHaveBeenCalledWith('test-app-id', 'mock-pem-key');
       expect(mockGitHubService.getInstallationId).toHaveBeenCalledWith('mock.jwt.token', 'test-org', "org", []);
       expect(mockGitHubService.getInstallationToken).toHaveBeenCalledWith('mock.jwt.token', 12345, [], undefined);
@@ -111,6 +111,8 @@ describe('run task logic', () => {
       expect(mockedTl.setVariable).toHaveBeenCalledWith(constants.INSTALLATIONID_OUTPUT_VARNAME, '12345', false);
       expect(mockedTl.setVariable).toHaveBeenCalledWith(constants.INSTALLATION_TOKEN_OUTPUT_VARNAME, 'ghs_mock_installation_token', true);
       expect(mockedTl.setVariable).toHaveBeenCalledWith(constants.TOKEN_EXPIRATION_OUTPUT_VARNAME, '2024-01-01T13:00:00Z', false);
+      expect(mockedTl.setVariable).toHaveBeenCalledWith(constants.GITHUB_HOST_OUTPUT_VARNAME, 'github.com', false);
+      expect(mockedTl.setVariable).toHaveBeenCalledWith(constants.GITHUB_API_URL_OUTPUT_VARNAME, 'https://api.github.com', false);
     });
 
     it('should complete successfully with direct certificate input', async () => {
@@ -143,9 +145,26 @@ describe('run task logic', () => {
       expect(mockedTl.setResult).not.toHaveBeenCalled();
     });
 
-    it('should use a custom API URL with direct inputs', async () => {
-      const customBaseUrl = 'https://github.enterprise.com/api/v3';
-
+    it.each([
+      {
+        scenario: 'standard GitHub Enterprise Cloud',
+        apiUrl: 'https://api.github.com/',
+        expectedApiUrl: 'https://api.github.com',
+        expectedHost: 'github.com'
+      },
+      {
+        scenario: 'GitHub Enterprise Cloud with data residency',
+        apiUrl: 'https://api.company.ghe.com/',
+        expectedApiUrl: 'https://api.company.ghe.com',
+        expectedHost: 'company.ghe.com'
+      },
+      {
+        scenario: 'GitHub Enterprise Server',
+        apiUrl: 'https://github.company.com/api/v3/',
+        expectedApiUrl: 'https://github.company.com/api/v3',
+        expectedHost: 'github.company.com'
+      }
+    ])('should expose the API URL and GitHub host for $scenario', async ({ apiUrl, expectedApiUrl, expectedHost }) => {
       mockedTl.getInput.mockImplementation((name: string) => {
         switch (name) {
           case 'owner':
@@ -155,7 +174,7 @@ describe('run task logic', () => {
           case 'certificate':
             return 'mock-pem-key';
           case 'apiUrl':
-            return customBaseUrl;
+            return apiUrl;
           default:
             return '';
         }
@@ -163,10 +182,12 @@ describe('run task logic', () => {
 
       await run();
 
-      expect(console.log).toHaveBeenCalledWith(`Base URL: ${customBaseUrl}`);
-      expect(ProxyConfig.fromAzurePipelines).toHaveBeenCalledWith(customBaseUrl);
-      expect(MockedGitHubService).toHaveBeenCalledWith(customBaseUrl, { proxy: mockProxyConfig });
-      expect(mockedTl.setTaskVariable).toHaveBeenCalledWith(constants.BASE_URL_TASK_VARNAME, customBaseUrl);
+      expect(console.log).toHaveBeenCalledWith(`Base URL: ${expectedApiUrl}`);
+      expect(ProxyConfig.fromAzurePipelines).toHaveBeenCalledWith(expectedApiUrl);
+      expect(MockedGitHubService).toHaveBeenCalledWith(expectedApiUrl, { proxy: mockProxyConfig });
+      expect(mockedTl.setVariable).toHaveBeenCalledWith(constants.GITHUB_API_URL_OUTPUT_VARNAME, expectedApiUrl, false);
+      expect(mockedTl.setVariable).toHaveBeenCalledWith(constants.GITHUB_HOST_OUTPUT_VARNAME, expectedHost, false);
+      expect(mockedTl.setTaskVariable).toHaveBeenCalledWith(constants.BASE_URL_TASK_VARNAME, expectedApiUrl);
     });
 
     it('should use the default API URL when the direct input is empty', async () => {

--- a/create-github-app-token/test/utils/constants.test.ts
+++ b/create-github-app-token/test/utils/constants.test.ts
@@ -27,6 +27,14 @@ describe('constants', () => {
     it('should define token expiration output variable name', () => {
       expect(constants.TOKEN_EXPIRATION_OUTPUT_VARNAME).toBe('tokenExpiration');
     });
+
+    it('should define GitHub host output variable name', () => {
+      expect(constants.GITHUB_HOST_OUTPUT_VARNAME).toBe('GitHubHost');
+    });
+
+    it('should define GitHub API URL output variable name', () => {
+      expect(constants.GITHUB_API_URL_OUTPUT_VARNAME).toBe('GitHubAPIUrl');
+    });
   });
 
   describe('task variable names', () => {

--- a/create-github-app-token/test/utils/github.test.ts
+++ b/create-github-app-token/test/utils/github.test.ts
@@ -1,4 +1,4 @@
-import { getRepoName, getOwnerName } from '../../src/utils/github';
+import { getGitHubHost, getRepoName, getOwnerName, normalizeGitHubApiUrl } from '../../src/utils/github';
 
 describe('github utilities', () => {
   describe('getRepoName', () => {
@@ -22,6 +22,22 @@ describe('github utilities', () => {
     it('should handle owner names with special characters', () => {
       const result = getOwnerName('org-name_with.dots/repo');
       expect(result).toBe('org-name_with.dots');
+    });
+  });
+
+  describe('normalizeGitHubApiUrl', () => {
+    it('should trim whitespace and trailing slashes', () => {
+      expect(normalizeGitHubApiUrl('  https://github.example.com/api/v3///  ')).toBe('https://github.example.com/api/v3');
+    });
+  });
+
+  describe('getGitHubHost', () => {
+    it.each([
+      ['GitHub Enterprise Cloud', 'https://api.github.com', 'github.com'],
+      ['GitHub Enterprise Cloud with data residency', 'https://api.company.ghe.com', 'company.ghe.com'],
+      ['GitHub Enterprise Server', 'https://github.company.com/api/v3', 'github.company.com']
+    ])('should derive the host for %s', (_scenario, apiUrl, expectedHost) => {
+      expect(getGitHubHost(apiUrl)).toBe(expectedHost);
     });
   });
 });

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "create-github-app-token",
     "name": "GitHub App Token Generator",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "publisher": "INSERT YOUR PUBLISHER HERE",
     "public": false,
     "targets": [


### PR DESCRIPTION
## Why

Pipelines that consume the generated installation token often need more than the
token itself. They also need to know which GitHub hostname and REST API base URL
the token belongs to.

Previously, examples and downstream scripts commonly hard-coded
`https://api.github.com`. This only works for standard GitHub Enterprise Cloud
and makes pipelines difficult to reuse across:

- GitHub Enterprise Cloud
- GitHub Enterprise Cloud with data residency (`*.ghe.com`)
- GitHub Enterprise Server

Each environment uses a different relationship between its GitHub hostname and
REST API URL:

| Environment | GitHub hostname | REST API base URL |
|-------------|-----------------|-------------------|
| GitHub Enterprise Cloud | `github.com` | `https://api.github.com` |
| GHEC with data residency | `company.ghe.com` | `https://api.company.ghe.com` |
| GitHub Enterprise Server | `github.company.com` | `https://github.company.com/api/v3` |

Requiring every pipeline to reproduce these rules creates duplicated and
error-prone endpoint handling. It also means a service connection can select the
correct API endpoint for token creation while subsequent scripts accidentally
call a different GitHub environment.

## What changed

This PR adds two task output variables:

- `GitHubHost`: the hostname expected by the GitHub CLI through `GH_HOST`
- `GitHubAPIUrl`: the normalized REST API base URL without a trailing slash

API URL normalization and host derivation are centralized in shared utilities
and reused by both the task and the GitHub service.

The README and pipeline examples now demonstrate using:

- `$(step.GitHubAPIUrl)` when constructing cURL request URLs
- `$(step.GitHubHost)` as the `GH_HOST` environment variable

## Benefits

- Makes the same pipeline portable across GitHub.com, GHE.com, and GHES
- Keeps token generation and subsequent API calls pointed at the same environment
- Removes hard-coded GitHub API URLs from scripts
- Prevents consumers from having to understand and duplicate GitHub endpoint rules
- Avoids malformed URLs caused by inconsistent trailing-slash handling
- Provides a straightforward way to configure GitHub CLI for non-default hosts
- Preserves existing behavior because the new outputs are additive
